### PR TITLE
Fix activity log API paths

### DIFF
--- a/frontend/my_pages/activity.py
+++ b/frontend/my_pages/activity.py
@@ -5,14 +5,14 @@ from frontend.utils.state import get_token
 def activity_page():
     st.title("📝 Activity Log")
     token = get_token()
-    res = api_get("/activity/log", token)
+    res = api_get("/user/log", token)
     logs = res.json() if res.ok else []
     st.write(logs)
     ticker = st.text_input("Log a Search (Ticker)")
     if st.button("Save Search"):
-        r = api_post("/activity/save_search", token, params={"ticker": ticker})
+        r = api_post("/user/save_search", token, params={"ticker": ticker})
         st.success(r.json().get("msg", "Search logged"))
     if st.button("Clear All Activity"):
-        r = api_delete("/activity/clear", token)
+        r = api_delete("/user/clear", token)
         st.success(r.json().get("msg", "Activity log cleared"))
         st.rerun()


### PR DESCRIPTION
## Summary
- correct endpoints in `activity_page` to match backend `/user` routes

## Testing
- `python -m py_compile frontend/my_pages/activity.py`

------
https://chatgpt.com/codex/tasks/task_e_6841ab143e34832698981a643b414aab