### PR TITLE
Add sentiment scoring to stock news

### DIFF
--- a/frontend/my_pages/news.py
+++ b/frontend/my_pages/news.py
@@ -5,11 +5,28 @@ def news_page():
     st.title("📰 Stock News Search")
     stock = st.text_input("Enter Stock Name or Symbol (e.g., RELIANCE)", "")
     if stock:
+        sort_order = st.selectbox(
+            "Sort By",
+            ["Newest", "Positive First", "Negative First"],
+            index=0,
+        )
         news = fetch_google_news(stock)
         if news:
+            if sort_order == "Positive First":
+                news.sort(key=lambda x: x["sentiment"], reverse=True)
+            elif sort_order == "Negative First":
+                news.sort(key=lambda x: x["sentiment"])
             for n in news:
-                st.markdown(f"**[{n['title']}]({n['link']})**  \n<sub>{n['published']}</sub>", unsafe_allow_html=True)
-                st.write(n['summary'])
+                st.markdown(
+                    f"**[{n['title']}]({n['link']})**  \n<sub>{n['published']}</sub>",
+                    unsafe_allow_html=True,
+                )
+                st.write(n["summary"])
+                sentiment_text = (
+                    "⬆️" if n["sentiment"] > 0 else "⬇️" if n["sentiment"] < 0 else "➖"
+                )
+                st.write(f"Sentiment Score: {n['sentiment']:.2f} {sentiment_text}")
                 st.divider()
         else:
             st.info("No news found for this stock.")
+

--- a/frontend/requirements.txt
+++ b/frontend/requirements.txt
@@ -3,3 +3,4 @@ requests
 pandas
 plotly
 python-dotenv
+textblob

--- a/frontend/utils/news.py
+++ b/frontend/utils/news.py
@@ -1,4 +1,5 @@
 import feedparser
+from textblob import TextBlob
 
 def fetch_google_news(stock):
     """Fetch news headlines and links for a given stock from Google News RSS."""
@@ -6,10 +7,13 @@ def fetch_google_news(stock):
     feed = feedparser.parse(url)
     news_list = []
     for entry in feed.entries:
+        text = f"{entry.title} {entry.summary}"
+        score = TextBlob(text).sentiment.polarity
         news_list.append({
             "title": entry.title,
             "link": entry.link,
             "published": entry.published,
-            "summary": entry.summary
+            "summary": entry.summary,
+            "sentiment": score
         })
     return news_list


### PR DESCRIPTION
## Summary
- analyze news headlines for sentiment using TextBlob
- display sentiment score and up/down icon in News page
- allow sorting news by positive/negative orientation
- add `textblob` dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841acf6d7688326991cd5d61b3cb6dc